### PR TITLE
Support variable-length PET IDs and indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ subPETs/
 SPM_Outputs/
 ANTs_Outputs/
 subPETs_forIlyaReview/
+PET_Space/
 
 # OS/editor clutter
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -59,19 +59,41 @@ fastreads/
 │   ├── voi_CerebGry_2mm.nii.gz
 │   └── voi_WhlCblBrnStm_2mm.nii.gz
 ├── subPETs/
-│   ├── w011002_PET_3D.nii
-│   ├── w011005_PET_3D.nii
+│   ├── w23_PET_3D.nii
+│   ├── w24_PET_3D.nii
 │   └── ...
 └── PET_Space/
-    ├── 011002_PET_3D.nii
-    ├── 011005_PET_3D.nii
+    ├── 23_PET_3D.nii
+    ├── 24_PET_3D.nii
     └── ...
 ```
 
-Input naming conventions:
+## Input filename and ID rules
 
-- `subPETs/`: filenames should include ID as `wXXXXXX` (for example, `w011002_PET_3D.nii`).
-- `PET_Space/`: filenames should follow `XXXXXX_PET_3D.nii` (for example, `011002_PET_3D.nii`).
+The viewer does not require 6-digit IDs anymore. It works with any numeric ID length, as long as the filenames match the expected PET naming pattern exactly.
+
+Accepted filename patterns:
+
+- `subPETs/`: `w<ID>_PET_3D.nii` or `w<ID>_PET_3D.nii.gz`
+- `PET_Space/`: `<ID>_PET_3D.nii` or `<ID>_PET_3D.nii.gz`
+
+Where:
+
+- `<ID>` must be digits only
+- the same `<ID>` should be used across both folders for the same subject
+- the viewer derives the subject ID from the numeric portion of the filename
+
+Examples:
+
+- `subPETs/w23_PET_3D.nii` pairs with `PET_Space/23_PET_3D.nii`
+- `subPETs/w011002_PET_3D.nii.gz` pairs with `PET_Space/011002_PET_3D.nii.gz`
+
+Important constraints:
+
+- Files that do not match these patterns are ignored by `server.py`.
+- Subjects are discovered from `subPETs/`. If a subject is missing from `subPETs/`, it will not appear in the viewer.
+- `PET_Space/` is optional per subject for PET view, but if its matching file is missing then that subject cannot be shown in PET mode.
+- The "Go to ID" field in `viewer.html` uses the first discovered subject ID to show the example digit count and example ID.
 
 ## Run it
 

--- a/server.py
+++ b/server.py
@@ -11,67 +11,53 @@ SUBPETS_DIR = "subPETs"
 PET_SPACE_DIR = "PET_Space"
 NOTES_CSV = "notes.csv"
 
-ID_RE = re.compile(r"w(\d{6})", re.IGNORECASE)
+SUBPETS_ID_RE = re.compile(r"^w(\d+)_PET_3D\.nii(?:\.gz)?$", re.IGNORECASE)
+PET_SPACE_ID_RE = re.compile(r"^(\d+)_PET_3D\.nii(?:\.gz)?$", re.IGNORECASE)
 VALID_EXT = (".nii", ".nii.gz")
 
 
-def _pick_best_file(folder, sid):
-    """
-    Choose a PET file for a given ID in a folder.
-    Preference: .nii (faster to decode) > .nii.gz
-    """
-    if not os.path.isdir(folder):
-        return None
+def _is_better_file(candidate, current):
+    if current is None:
+        return True
+    candidate_key = (0 if candidate.lower().endswith(".nii") else 1, candidate)
+    current_key = (0 if current.lower().endswith(".nii") else 1, current)
+    return candidate_key < current_key
 
-    candidates = []
-    for fn in os.listdir(folder):
-        lower = fn.lower()
+
+def _index_pet_files(folder, pattern):
+    indexed = {}
+    if not os.path.isdir(folder):
+        return indexed
+
+    for entry in os.scandir(folder):
+        if not entry.is_file():
+            continue
+        lower = entry.name.lower()
         if not lower.endswith(VALID_EXT):
             continue
-        m = ID_RE.search(fn)
-        if not m:
+        match = pattern.match(entry.name)
+        if not match:
             continue
-        if m.group(1) != sid:
-            continue
-        candidates.append(fn)
-
-    if not candidates:
-        return None
-
-    # Prefer .nii over .nii.gz
-    candidates.sort(key=lambda x: (0 if x.lower().endswith(".nii") else 1, x))
-    return candidates[0]
+        sid = match.group(1)
+        current = indexed.get(sid)
+        if _is_better_file(entry.name, current):
+            indexed[sid] = entry.name
+    return indexed
 
 
 def list_subjects():
-    # Build set of IDs from full-res folder
-    ids = set()
-    if os.path.isdir(SUBPETS_DIR):
-        for fn in os.listdir(SUBPETS_DIR):
-            lower = fn.lower()
-            if not lower.endswith(VALID_EXT):
-                continue
-            m = ID_RE.search(fn)
-            if m:
-                ids.add(m.group(1))
-
+    full_files = _index_pet_files(SUBPETS_DIR, SUBPETS_ID_RE)
+    pet_space_files = _index_pet_files(PET_SPACE_DIR, PET_SPACE_ID_RE)
     subjects = []
-    for sid in ids:
-        full_fn = _pick_best_file(SUBPETS_DIR, sid)
-        pet_space_fn = f"{sid}_PET_3D.nii"
-        pet_space_abs = os.path.join(PET_SPACE_DIR, pet_space_fn)
-        pet_space_path = f"{PET_SPACE_DIR}/{pet_space_fn}" if os.path.isfile(pet_space_abs) else None
+    for sid, full_fn in full_files.items():
+        pet_space_fn = pet_space_files.get(sid)
+        subjects.append({
+            "id": sid,
+            "full_path": f"{SUBPETS_DIR}/{full_fn}",
+            "pet_space_path": f"{PET_SPACE_DIR}/{pet_space_fn}" if pet_space_fn else None,
+        })
 
-        full_path = f"{SUBPETS_DIR}/{full_fn}" if full_fn else None
-
-        if full_path:
-            subjects.append({
-                "id": sid,
-                "full_path": full_path,
-                "pet_space_path": pet_space_path,
-            })
-
-    subjects.sort(key=lambda x: int(x["id"]))
+    subjects.sort(key=lambda x: (int(x["id"]), x["id"]))
     return subjects
 
 
@@ -98,7 +84,7 @@ def write_notes_csv(notes_map, subject_ids=None):
         for sid in subject_ids:
             rows.append({"ID": sid, "IN_Notes": notes_map.get(sid, "")})
     else:
-        for sid in sorted(notes_map.keys(), key=lambda x: int(x)):
+        for sid in sorted(notes_map.keys(), key=lambda x: (int(x), x)):
             rows.append({"ID": sid, "IN_Notes": notes_map.get(sid, "")})
 
     with open(NOTES_CSV, "w", encoding="utf-8", newline="") as f:
@@ -145,15 +131,17 @@ class Handler(SimpleHTTPRequestHandler):
             if not isinstance(notes_map, dict):
                 return self._send_json({"ok": False, "error": "notes must be an object/dict"}, status=400)
 
+            subjects = list_subjects()
+            subject_ids = [s["id"] for s in subjects]
+            subject_id_set = set(subject_ids)
+
             cleaned = {}
             for k, v in notes_map.items():
                 sid = str(k).strip()
-                if not re.fullmatch(r"\d{6}", sid):
+                if sid not in subject_id_set:
                     continue
                 cleaned[sid] = "" if v is None else str(v)
 
-            subjects = list_subjects()
-            subject_ids = [s["id"] for s in subjects]
             write_notes_csv(cleaned, subject_ids=subject_ids)
 
             return self._send_json({"ok": True, "written": NOTES_CSV, "count": len(cleaned)})

--- a/viewer.html
+++ b/viewer.html
@@ -69,9 +69,9 @@
       <button id="nextBtn">Next →</button>
     </div>
 
-    <div class="label" style="margin-top:6px;">Go to ID (6 digits)</div>
+    <div class="label" style="margin-top:6px;">Go to ID (<span id="gotoDigits">?</span> digits)</div>
     <div class="row">
-      <input id="gotoInput" class="mono" placeholder="e.g., 011002" maxlength="6" type="text" />
+      <input id="gotoInput" class="mono" placeholder="Loading IDs..." type="text" />
       <button id="goBtn">Go</button>
     </div>
 
@@ -187,6 +187,7 @@
 
     const notesEl = document.getElementById("notes");
     const gotoInput = document.getElementById("gotoInput");
+    const gotoDigits = document.getElementById("gotoDigits");
 
     const prevBtn = document.getElementById("prevBtn");
     const nextBtn = document.getElementById("nextBtn");
@@ -335,6 +336,16 @@
     let idx = 0;
     let currentId = null;
     let currentView = VIEW.PET; // default at startup
+    let defaultSearchId = "";
+    let defaultSearchIdDigits = null;
+
+    function configureIdSearchUi() {
+      defaultSearchId = subjects[0]?.id || "";
+      defaultSearchIdDigits = defaultSearchId.length || null;
+      gotoDigits.textContent = defaultSearchIdDigits ? String(defaultSearchIdDigits) : "?";
+      gotoInput.placeholder = defaultSearchId ? `e.g., ${defaultSearchId}` : "Enter subject ID";
+      gotoInput.maxLength = defaultSearchId ? defaultSearchId.length : 32;
+    }
 
     async function loadAtlasOnce() {
       if (atlasLoaded) return;
@@ -625,9 +636,17 @@
 
     goBtn.addEventListener("click", () => {
       const id = (gotoInput.value || "").trim();
-      if (!/^\d{6}$/.test(id)) { statusEl.textContent = "Enter a 6-digit ID."; return; }
+      if (!id) {
+        const digitText = defaultSearchIdDigits ? `${defaultSearchIdDigits}-digit ` : "";
+        statusEl.textContent = `Enter a ${digitText}ID${defaultSearchId ? ` like ${defaultSearchId}` : ""}.`;
+        return;
+      }
       const j = findIndexById(id);
-      if (j < 0) { statusEl.textContent = `ID ${id} not found.`; return; }
+      if (j < 0) {
+        const hint = defaultSearchId ? ` Example: ${defaultSearchId}.` : "";
+        statusEl.textContent = `ID ${id} not found.${hint}`;
+        return;
+      }
       loadSubjectByIndex(j);
     });
 
@@ -666,6 +685,7 @@
           pet_space_path: s.pet_space_path || null
         }));
         if (!subjects.length) { statusEl.textContent = "No PETs found in subPETs/."; return; }
+        configureIdSearchUi();
         scountEl.textContent = String(subjects.length);
 
         // merge notes.csv from server into local (local wins)


### PR DESCRIPTION
Allow numeric IDs of any length and improve file discovery/UI. Updated server.py to index subPETs/ and PET_Space/ by filename patterns (_index_pet_files) and prefer .nii over .nii.gz (_is_better_file). list_subjects now builds subject records from indexed files and note-writing/sorting uses robust int+string keys. The notes handler validates submitted notes against discovered subject IDs (no longer requires 6-digit IDs). viewer.html was updated to show dynamic digit hint, adaptive placeholder/maxlength, and friendlier validation/messages. README and .gitignore updated (add PET_Space/, document new filename/ID patterns and constraints).